### PR TITLE
Added middleware to filter commnds for other bots in groups :tada:

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -32,6 +32,31 @@ let victims = []; //Array of victims
 let enabled = true; //wheter or not the bot will spam the victims.
 
 /* ======================================
+*				Middleware
+ ====================================== */
+
+bot.use((ctx, next) => {
+	if (ctx.chat.type === "private") {
+		next();
+		return;
+	}
+
+	const validator = /^\/\w*(@|\w)*/;
+	if (!validator.test(ctx.message.text)) {
+		next();
+		return;
+	}
+	
+	const command = ctx.message.text.replace(/^\/\w*/, "");
+	const botnameValidator = new RegExp(`^@${ctx.me}`);
+
+	if (botnameValidator.test(command)) {
+		next();
+		return;
+	}
+});
+
+/* ======================================
 *				Commands
  ====================================== */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spammer-telegram-bot",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "private": true,
   "description": "A small telegram bot to annoy people on telegram",
   "main": "bot.js",


### PR DESCRIPTION
# This command middleware it's the way!!

[telegraf js](https://telegraf.js.org/) on it's great wisdom decided to pass all commands in groups and super groups to the bot, regardless of which bot is being called by them (example: you send `/ping@botA` on a group chat, only `@botA` should react to that command. But if a `@botB` is on the group, sees the command and it's using telegraf, the bot will assume the command is directed at him). With this new middleware function I check for messages that are commands and then I ignore those that are not directed at the bot :godmode:.