### PR TITLE
Fix: improved the error log and added guard

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -8,19 +8,19 @@ const path = require("path");
 require("dotenv").config();
 const { Telegraf } = require("telegraf");
 
-const { printLog, printError, getArgsFromMsg } = require("./imports/utilities");
+const { printLog, printErrorMsg, getArgsFromMsg } = require("./imports/utilities");
 //const { startServer, startServerWithHooks } = require("./imports/server");
 const { CreatePersistance } = require("./imports/persistance");
 
 const { TELEGRAM, ADMIN, PORT, URL } = process.env;
 
 if (!TELEGRAM) {
-	printError("Error: No TELEGRAM variable in enviorement.\nPerhaps you forgot to include it?");
+	printErrorMsg("Error: No TELEGRAM variable in enviorement.\nPerhaps you forgot to include it?");
 	process.exit(1);
 }
 
 if (!ADMIN) {
-	printError("Error: No ADMIN variable in enviorement.\nPerhaps you forgot to include it?");
+	printErrorMsg("Error: No ADMIN variable in enviorement.\nPerhaps you forgot to include it?");
 	process.exit(1);
 }
 
@@ -51,6 +51,11 @@ let persistance = {};
 bot.use((ctx, next) => {
 	if (ctx.chat.type === "private") {
 		next();
+		return;
+	}
+
+	if(!ctx.message) {
+		// if message is undefined, we ignore this call.
 		return;
 	}
 
@@ -245,19 +250,13 @@ bot.catch((err, ctx) => {
 	const chatErr = ctx.chat;
 	const metaMessage = `Error found in ${chatErr.type} chat ${chatErr.title??chatErr.username}`;
 	const message = `The message that triggered the error was: ${ctx.message?.text}`;
-	const { inspect } = require("node:util");
 	//const ctxObj = JSON.stringify(ctx, null, 2);
-	const ctxObj = inspect(ctx, {
-		depth: 5,
-		compact: false,
-		getters: true,
-		numericSeparator: true,
-	});
+	const ctxObj = JSON.stringify({ chat: ctx.chat, update: ctx.update}, null, 2);
 
-	printError(err);
-	printError(metaMessage);
-	printError(message);
-	printError(ctxObj);
+	printErrorMsg(metaMessage);
+	printErrorMsg(message);
+	printErrorMsg(ctxObj);
+	console.error(err);
 });
 
 /* ======================================

--- a/imports/utilities.js
+++ b/imports/utilities.js
@@ -29,7 +29,7 @@ function printLog(message) {
  * error level.
  * @param {String} message Error message to print
  */
-function printError(message) {
+function printErrorMsg(message) {
 	callLog(console.error, message);
 }
 
@@ -54,5 +54,5 @@ module.exports = {
 	dateNow,
 	getArgsFromMsg,
 	printLog,
-	printError
+	printErrorMsg
 };


### PR DESCRIPTION
The error object being sent naively to "printError" would not print the stack trace. I decided it was better for that method to print a simple error message but not the object, instead using "console.error". On the other hand, I realized printing the full context object was not necessary, instead it's better to just print the chat and update properties from it. Lastly, I noticed that the error being triggered was due to the bot receiving the "edit message" event and handling it badly on the middleware function (the message object was undefined), this should fix that error too.